### PR TITLE
Strip start and end of thermostat name

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,33 +58,32 @@ see. For example:
 ```
 $ eco2 scan
 Scanning for 2 minutes. Please wait.
-0;0:04:2F:C0:F2:58;eTRV - address: 66:66:64:35:37:30
-0;0:04:2F:06:24:D1;eTRV - address: 61:61:35:66:61:39
-0;0:04:2F:C0:F3:0C;eTRV - address: 33:62:31:63:64:66
-0;0:04:2F:06:24:DD;eTRV - address: 35:39:66:66:61:64
+0:04:2F:C0:F2:58
+0:04:2F:06:24:D1
+0:04:2F:C0:F3:0C
+0:04:2F:06:24:DD
 ```
 
 ### Reading from a thermostat
 You can now read from any of the thermostats shown by the `scan` command. You do
-that by taking one of the values in the first column shown by the `scan`
-output - for example `0;0:04:2F:06:24:D1;eTRV` from line 2 in the output above.
+that by taking one of the values shown by the `scan` output - for example
+`0:04:2F:06:24:D1` the output above. (In fact, this corresponds to the "MAC Address"
+that you can see in the Eco 2 app by choosing your thermostat, going to Settings,
+and choosing System Information.)
 
-If this is the first time you connect to the thermostat, the `scan` command needs
+If this is the first time you connect to the thermostat, the `read` command needs
 to be able to read a secret key from the thermostat. As you may remember when
 setting up your thermostat from the app, you are required to click the timer button
 on the thermostat. The app asks you to do this and magically finds out when you have
 clicked the button. This tool instead asks you to click the button and subsequently
 press enter on your keyboard.
 
-Also, remember to put the thermostat serial number in quotes, or your shell will get
-very confused.
-
 Example:
 
 ```
-$ eco2 read '0;0:04:2F:06:24:D1;eTRV'
-Reading from 0;0:04:2F:06:24:D1;eTRV for the first time...
-.....Got our peripheral: 0;0:04:2F:06:24:D1;eTRV
+$ eco2 read 0:04:2F:06:24:D1
+Reading from 0:04:2F:06:24:D1 for the first time...
+.....Found thermostat
 This is the first time you connect to this thermostat, so we need to fetch the secret key.
 Please click the timer button on the thermostat, then press enter on your keyboard to continue connecting.
 
@@ -98,7 +97,7 @@ That's it. We have now read all relevant values from the thermostat.
 Of course you want to see what we just read. So you should use the `show` command.
 
 ```
-$ eco2 show '0;0:04:2F:06:24:D1;eTRV'
+$ eco2 show 0:04:2F:06:24:D1
 Name: Alrum opgang
 
 Set-point/room temperature: 19°C / 23.5°C

--- a/README.md
+++ b/README.md
@@ -44,12 +44,21 @@ official apps. I think it's OK if you need to use the app to enable or disable
 adaptive learning, to switch between horizontal and vertical installation, and
 other things that you will probably only do once when setting up the thermostat.
 
-## Usage
-You can run all commands through `cargo run`, or you can do `cargo build` once,
-put the resulting `target/debug/eco2` command on your path, and just run `eco2`.
-Below, we assume the latter.
+## Building
+You gotta [install Rust](https://www.rust-lang.org/tools/install) first. Then
+you can build the tool in release mode with `cargo build --release`, put
+`target/release/eco2` on your path, and then just call e.g. `eco2 scan`.
 
-For now, only the `scan`, `read`, and `show` commands are implemented.
+If you are lazy, you can also just build in debug mode and run in one fell
+swoop by running e.g. `cargo run scan`.
+
+Run the unit tests with `cargo test -- --test-threads=1`. The `-- --test-threads=1`
+is necessary because a couple of the tests write to and read from a file on
+disk, so they are flaky when run in parallel. (If you know how to set this up
+in `Cargo.toml`, please send me a PR...)
+
+## Usage
+For now, only the `eco2 scan`, `eco2 read`, and `eco2 show` commands are implemented.
 
 ### Scanning for nearby thermostats
 Run `eco2 scan`, wait 2 minutes, and see which thermostats your computer could

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ you can build the tool in release mode with `cargo build --release`, put
 `target/release/eco2` on your path, and then just call e.g. `eco2 scan`.
 
 If you are lazy, you can also just build in debug mode and run in one fell
-swoop by running e.g. `cargo run scan`.
+swoop by running e.g. `cargo run scan` on your command-line.
 
 Run the unit tests with `cargo test -- --test-threads=1`. The `-- --test-threads=1`
 is necessary because a couple of the tests write to and read from a file on

--- a/src/bluetooth.rs
+++ b/src/bluetooth.rs
@@ -204,7 +204,8 @@ pub fn scan(duration: Duration) -> Vec<ScannedBluetoothPeripheral> {
     result
 }
 
-pub fn connect(name: &String, ensure_timer_button_pressed: bool) -> Result<ConnectedBluetoothPeripheral> {
+pub fn connect<F>(matches_name: F, ensure_timer_button_pressed: bool) -> Result<ConnectedBluetoothPeripheral>
+    where F: Fn(&String) -> bool {
     let manager = Manager::new().unwrap();
     let central = get_central(&manager);
 
@@ -219,8 +220,8 @@ pub fn connect(name: &String, ensure_timer_button_pressed: bool) -> Result<Conne
         for peripheral in central.peripherals().into_iter() {
             match peripheral.properties().local_name {
                 Some(peripheral_name) => {
-                    if &peripheral_name == name {
-                        eprintln!("Got our peripheral: {}", name);
+                    if matches_name(&peripheral_name) {
+                        eprintln!("Found thermostat");
                         if ensure_timer_button_pressed {
                             eprintln!("This is the first time you connect to this thermostat, so we need to fetch the secret key.");
                             eprintln!("Please click the timer button on the thermostat, then press enter on your keyboard to continue connecting.");

--- a/src/commands/read.rs
+++ b/src/commands/read.rs
@@ -4,6 +4,7 @@ use std::collections::HashSet;
 mod bluetooth;
 
 use crate::models::thermostats::{Thermostats, Thermostat};
+use crate::models::thermostat_names::*;
 
 pub fn execute(arguments: Vec<String>) {
     if arguments.len() != 1 {
@@ -24,7 +25,7 @@ pub fn execute(arguments: Vec<String>) {
     } else {
         eprintln!("Reading from {}...", serial);
     }
-    let connected_peripheral = bluetooth::connect(serial, first_connection).unwrap();
+    let connected_peripheral = bluetooth::connect(|name| { is_thermostat_name(name) && &stripped_name(name) == serial }, first_connection).unwrap();
 
     let mut characteristics_to_read = HashSet::new();
     if first_connection {

--- a/src/commands/scan.rs
+++ b/src/commands/scan.rs
@@ -3,14 +3,16 @@ use std::time::Duration;
 #[path = "../bluetooth.rs"]
 mod bluetooth;
 
+use crate::models::thermostat_names::*;
+
 pub fn execute(arguments: Vec<String>) {
     eprintln!("Scanning for 2 minutes. Please wait.");
     let peripherals = bluetooth::scan(Duration::from_secs(120));
 
     let mut peripheral_found = false;
     for peripheral in peripherals.iter() {
-        if peripheral.name.ends_with(";eTRV") {
-            println!("{} - address: {}", peripheral.name, peripheral.address);
+        if is_thermostat_name(&peripheral.name) {
+            println!("{}", stripped_name(&peripheral.name));
             peripheral_found = true
         }
     }

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,2 +1,3 @@
 pub mod thermostats;
 pub mod parsed_thermostat;
+pub mod thermostat_names;

--- a/src/models/parsed_thermostat.rs
+++ b/src/models/parsed_thermostat.rs
@@ -439,7 +439,7 @@ mod tests {
 
     fn create_parsed_thermostat() -> ParsedThermostat {
         let thermostat = Thermostat {
-            serial: "2;0:04:2F:06:24:D1;eTRV".to_string(),
+            serial: "0:04:2F:06:24:D1".to_string(),
             secret: vec![215u8, 91, 125, 126, 14, 118, 62, 143, 121, 48, 110, 175, 112, 218, 245, 65],
             name: vec![177u8, 174, 159, 196, 58, 140, 76, 22, 18, 192, 117, 144, 240, 100, 45, 250],
             temperature: vec![7u8, 148, 108, 151, 150, 177, 75, 43],
@@ -454,7 +454,7 @@ mod tests {
 
     fn create_parsed_thermostat_with_schedule() -> ParsedThermostat {
         let thermostat = Thermostat {
-            serial: "2;0:04:2F:06:24:D1;eTRV".to_string(),
+            serial: "0:04:2F:06:24:D1".to_string(),
             secret: vec![215u8, 91, 125, 126, 14, 118, 62, 143, 121, 48, 110, 175, 112, 218, 245, 65],
             name: vec![177u8, 174, 159, 196, 58, 140, 76, 22, 18, 192, 117, 144, 240, 100, 45, 250],
             temperature: vec![206u8, 158, 231, 129, 243, 102, 119, 22],
@@ -469,7 +469,7 @@ mod tests {
 
     fn create_parsed_thermostat_with_vacation_schedule() -> ParsedThermostat {
         let thermostat = Thermostat {
-            serial: "2;0:04:2F:06:24:D1;eTRV".to_string(),
+            serial: "0:04:2F:06:24:D1".to_string(),
             secret: vec![215u8, 91, 125, 126, 14, 118, 62, 143, 121, 48, 110, 175, 112, 218, 245, 65],
             name: vec![177u8, 174, 159, 196, 58, 140, 76, 22, 18, 192, 117, 144, 240, 100, 45, 250],
             temperature: vec![87u8, 121, 70, 227, 189, 210, 0, 110],
@@ -485,7 +485,7 @@ mod tests {
 
     fn create_parsed_thermostat_with_planned_vacation() -> ParsedThermostat {
         let thermostat = Thermostat {
-            serial: "2;0:04:2F:06:24:D1;eTRV".to_string(),
+            serial: "0:04:2F:06:24:D1".to_string(),
             secret: vec![215u8, 91, 125, 126, 14, 118, 62, 143, 121, 48, 110, 175, 112, 218, 245, 65],
             name: vec![177u8, 174, 159, 196, 58, 140, 76, 22, 18, 192, 117, 144, 240, 100, 45, 250],
             temperature: vec![206u8, 158, 231, 129, 243, 102, 119, 22],

--- a/src/models/thermostat_names.rs
+++ b/src/models/thermostat_names.rs
@@ -1,0 +1,85 @@
+pub fn is_thermostat_name(name: &String) -> bool {
+    let parts: Vec<&str> = name.split(';').collect();
+    if parts.len() != 3 {
+        return false;
+    }
+    
+    // Should start with a single digit and end with ";eTRV"
+    if !is_single_digit(parts[0]) || parts[2] != "eTRV" {
+        return false;
+    }
+
+    // Middle part is a single digit, followed by hex bytes separated by :
+    let middle_parts: Vec<&str> = parts[1].split(':').collect();
+    middle_parts.len() == 6
+        && is_single_digit(middle_parts[0])
+        && is_hexadecimal_byte(middle_parts[1])
+        && is_hexadecimal_byte(middle_parts[2])
+        && is_hexadecimal_byte(middle_parts[3])
+        && is_hexadecimal_byte(middle_parts[4])
+        && is_hexadecimal_byte(middle_parts[5])
+}
+
+pub fn stripped_name(name: &String) -> String {
+    if !is_thermostat_name(name) {
+        panic!("Not a thermostat name: {}", name);
+    }
+    let mut parts = name.split(';');
+    parts.next();
+    parts.next().unwrap().to_string()
+}
+
+fn is_single_digit(s: &str) -> bool {
+    s.len() == 1 && s.chars().all(|c| c.is_ascii_digit())
+}
+
+fn is_hexadecimal_byte(s: &str) -> bool {
+    s.len() == 2 && s.chars().all(|c| c.is_ascii_hexdigit())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_knows_what_is_a_thermostat_name() {
+        assert_eq!(true, is_thermostat_name(&"0;0:04:2F:06:24:D1;eTRV".to_string()));
+        assert_eq!(true, is_thermostat_name(&"4;0:04:2F:C0:F2:58;eTRV".to_string()));
+        assert_eq!(true, is_thermostat_name(&"2;0:04:2F:06:24:DD;eTRV".to_string()));
+    }
+
+    #[test]
+    fn it_knows_that_thermostat_names_do_not_start_with_non_digits() {
+        assert_eq!(false, is_thermostat_name(&"A;0:04:2F:06:24:D1;eTRV".to_string()));
+        assert_eq!(false, is_thermostat_name(&"a;0:04:2F:06:24:D1;eTRV".to_string()));
+        assert_eq!(false, is_thermostat_name(&"*;0:04:2F:06:24:D1;eTRV".to_string()));
+    }
+
+    #[test]
+    fn it_knows_that_thermostat_names_should_end_with_eTRV() {
+        assert_eq!(false, is_thermostat_name(&"0;0:04:2F:06:24:D1".to_string()));
+        assert_eq!(false, is_thermostat_name(&"4;0:04:2F:C0:F2:58;eTRV3".to_string()));
+        assert_eq!(false, is_thermostat_name(&"2;0:04:2F:06:24:DD;3eTRV".to_string()));
+    }
+
+    #[test]
+    fn it_knows_that_middle_part_should_be_only_colons_and_hexadecimals() {
+        assert_eq!(false, is_thermostat_name(&"0;0:G4:2F:06:24:D1;eTRV".to_string()));
+        assert_eq!(false, is_thermostat_name(&"4;0:_4:2F:C0:F2:58;eTRV".to_string()));
+        assert_eq!(false, is_thermostat_name(&"2;0:04;2F:06:24:DD;eTRV".to_string()));
+    }
+
+    #[test]
+    fn it_knows_that_middle_part_should_be_one_digit_and_five_hex_bytes() {
+        assert_eq!(false, is_thermostat_name(&"0;0:2F:06:24:D1;eTRV".to_string()));
+        assert_eq!(false, is_thermostat_name(&"0;04:2F:06:24:D1;eTRV".to_string()));
+        assert_eq!(false, is_thermostat_name(&"0;0:0:2F:06:24:D1;eTRV".to_string()));
+        assert_eq!(false, is_thermostat_name(&"0;0:04:2F:06:24:D1:D2;eTRV".to_string()));
+    }
+
+    #[test]
+    fn it_can_trim_thermostat_name() {
+        assert_eq!("0:04:2F:06:24:D1", stripped_name(&"0;0:04:2F:06:24:D1;eTRV".to_string()));
+    }
+
+}


### PR DESCRIPTION
There's no use of storing the parts of the Bluetooth peripheral name before the first `;` and after the last `;`. Especially since it seems like what's in front of the first `;` seems to rotate over time.

Closes #4 